### PR TITLE
BuildFix: Change outputpath of unit test project to 'scratch'

### DIFF
--- a/src/PPWCode.Vernacular.nHibernate.I.Tests/PPWCode.Vernacular.nHibernate.I.Tests.csproj
+++ b/src/PPWCode.Vernacular.nHibernate.I.Tests/PPWCode.Vernacular.nHibernate.I.Tests.csproj
@@ -16,18 +16,20 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\..\scratch\bin\PPWCode.Vernacular.nHibernate.I.Tests-Debug-AnyCPU\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <NoWarn>1591,1592,1573,1571,1570,1572</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\..\scratch\bin\PPWCode.Vernacular.nHibernate.I.Tests-Release-AnyCPU\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <NoWarn>1591,1592,1573,1571,1570,1572</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Change outputpath of unit test project to 'scratch'
this way it is consistent with the other ppwcode-projects
