### PR TITLE
Support 3 identifier formats

### DIFF
--- a/src/III.Tests/TestsSimpleModelMapper.cs
+++ b/src/III.Tests/TestsSimpleModelMapper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2020 by PeopleWare n.v..
+﻿// Copyright 2020-2022 by PeopleWare n.v..
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -48,8 +48,9 @@ namespace PPWCode.Vernacular.NHibernate.III.Tests
         protected override bool AdjustColumnForForeignGenerator
             => true;
 
-        public override bool UseCamelCaseUnderScoreForDbObjects
-            => false;
+        /// <inheritdoc />
+        public override IdentifierFormat IdentifierFormat
+            => IdentifierFormat.AS_IS;
 
         public override bool QuoteIdentifiers
             => true;

--- a/src/III.Tests/Utilities/StringUtilTests.cs
+++ b/src/III.Tests/Utilities/StringUtilTests.cs
@@ -1,0 +1,39 @@
+// Copyright 2022 by PeopleWare n.v..
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using NUnit.Framework;
+
+namespace PPWCode.Vernacular.NHibernate.III.Tests.Utilities
+{
+    [TestFixture]
+    public class StringUtilTests
+    {
+        [TestCase("MyTestIdentifier", "my_test_identifier")]
+        [TestCase("KBONumber", "kbo_number")]
+        [TestCase("C4Model", "c4_model")]
+        [TestCase("F15Jet", "f15_jet")]
+        [TestCase("AMD64InstructionSet", "amd64_instruction_set")]
+        public void ConversionSnakeCase(string original, string transformed)
+        {
+            Assert.AreEqual(transformed, StringUtil.ConvertFromPascalCaseToSnakeCase(original));
+        }
+
+        [TestCase("MyTestIdentifier", "MY_TEST_IDENTIFIER")]
+        [TestCase("KBONumber", "KBO_NUMBER")]
+        [TestCase("C4Model", "C4_MODEL")]
+        [TestCase("F15Jet", "F15_JET")]
+        [TestCase("AMD64InstructionSet", "AMD64_INSTRUCTION_SET")]
+        public void ConversionScreamingSnakeCase(string original, string transformed)
+        {
+            Assert.AreEqual(transformed, StringUtil.ConvertFromPascalCaseToScreamingSnakeCase(original));
+        }
+    }
+}

--- a/src/III/Interfaces/IPpwHbmMapping.cs
+++ b/src/III/Interfaces/IPpwHbmMapping.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 by PeopleWare n.v..
+﻿// Copyright 2018-2022 by PeopleWare n.v..
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -64,10 +64,7 @@ namespace PPWCode.Vernacular.NHibernate.III
         /// </returns>
         bool QuoteIdentifiers { get; }
 
-        bool UseCamelCaseUnderScoreForDbObjects { get; }
-
-        [ContractAnnotation("null => null; notnull => notnull")]
-        string CamelCaseToUnderscore(string camelCase);
+        IdentifierFormat IdentifierFormat { get; }
 
         [ContractAnnotation("null => null; notnull => notnull")]
         string GetIdentifier(string identifier);

--- a/src/III/MappingByCode/IdentifierFormat.cs
+++ b/src/III/MappingByCode/IdentifierFormat.cs
@@ -1,0 +1,45 @@
+// Copyright 2022 by PeopleWare n.v..
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace PPWCode.Vernacular.NHibernate.III.MappingByCode
+{
+    public enum IdentifierFormat
+    {
+        /// <summary>
+        ///     Keep the names of the identifiers as defined for class names and
+        ///     property names.
+        /// </summary>
+        /// <example>
+        ///     MyTestIdentifier => MyTestIdentifier
+        /// </example>
+        AS_IS = 1,
+
+        /// <summary>
+        ///     Convert the names of the identifiers as defined for class names
+        ///     and property names to snake case.  Assume that the original
+        ///     identifier is in pascal case.
+        /// </summary>
+        /// <example>
+        ///     MyTestIdentifier => my_test_identifier
+        /// </example>
+        PASCAL_CASE_TO_SNAKE_CASE,
+
+        /// <summary>
+        ///     Convert the names of the identifiers as defined for class names
+        ///     and property names to screaming snake case.  Assume that the
+        ///     original identifier is in pascal case.
+        /// </summary>
+        /// <example>
+        ///     MyTestIdentifier => MY_TEST_IDENTIFIER
+        /// </example>
+        PASCAL_CASE_TO_SCREAMING_SNAKE_CASE
+    }
+}

--- a/src/III/MappingByCode/SimpleModelMapper.cs
+++ b/src/III/MappingByCode/SimpleModelMapper.cs
@@ -99,8 +99,8 @@ namespace PPWCode.Vernacular.NHibernate.III.MappingByCode
             ModelMapper.BeforeMapAny += MemberReadOnlyAccessor;
         }
 
-        public override bool UseCamelCaseUnderScoreForDbObjects
-            => false;
+        public override IdentifierFormat IdentifierFormat
+            => IdentifierFormat.AS_IS;
 
         protected virtual bool DynamicInsert
             => false;
@@ -367,7 +367,7 @@ namespace PPWCode.Vernacular.NHibernate.III.MappingByCode
                 discriminatorValue = discriminatorValue.Substring(0, discriminatorValue.Length - "Enum".Length);
             }
 
-            return CamelCaseToUnderscore(discriminatorValue);
+            return StringUtil.ConvertFromPascalCaseToScreamingSnakeCase(discriminatorValue);
         }
 
         [JetBrains.Annotations.NotNull]

--- a/src/III/Utilities/StringUtil.cs
+++ b/src/III/Utilities/StringUtil.cs
@@ -1,0 +1,44 @@
+// Copyright 2022 by PeopleWare n.v..
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text.RegularExpressions;
+
+using JetBrains.Annotations;
+
+namespace PPWCode.Vernacular.NHibernate.III
+{
+    public static class StringUtil
+    {
+        [ContractAnnotation("null => null; notnull => notnull")]
+        private static string ConvertFromPascalCaseToUnderscores(string original)
+        {
+            const string Rgx = @"([A-Z]+)([A-Z][a-z])";
+            const string Rgx2 = @"([a-z\d])([A-Z])";
+
+            if (original != null)
+            {
+                string result = Regex.Replace(original, Rgx, "$1_$2");
+                result = Regex.Replace(result, Rgx2, "$1_$2");
+                return result;
+            }
+
+            return null;
+        }
+
+        [ContractAnnotation("null => null; notnull => notnull")]
+        public static string ConvertFromPascalCaseToSnakeCase(string original)
+            => ConvertFromPascalCaseToUnderscores(original)?.ToLowerInvariant();
+
+        [ContractAnnotation("null => null; notnull => notnull")]
+        public static string ConvertFromPascalCaseToScreamingSnakeCase(string original)
+            => ConvertFromPascalCaseToUnderscores(original)?.ToUpperInvariant();
+    }
+}


### PR DESCRIPTION
Support for 3 identifier formats (assume source is pascal case):
* as-is
* snake case (lower case)
* screaming snake case (upper case)